### PR TITLE
Remove multiple declaration of SENSOR const in the sensor classes

### DIFF
--- a/lib/rails_ids/sensors/blacklist_input_validation.rb
+++ b/lib/rails_ids/sensors/blacklist_input_validation.rb
@@ -6,7 +6,6 @@ module RailsIds
     # A implementation of an input validation sensor that blacklists some input.
     #
     class BlacklistInputValidation < Sensor
-      SENSOR = 'BlacklistInputValidation'.freeze
       SQL_INJECTION_REGEX = {
         'suspicious' => [
           %r(';)
@@ -47,7 +46,7 @@ module RailsIds
           rs.each do |r|
             next if not_matching?(params, r)
             event_detected(type: type, weight: weight, log: "found #{r}",
-                           sensor: SENSOR, request: request, params: params,
+                           request: request, params: params,
                            user: user, identifier: identifier, match: match(params, r))
           end
         end

--- a/lib/rails_ids/sensors/integer_overflow.rb
+++ b/lib/rails_ids/sensors/integer_overflow.rb
@@ -6,11 +6,10 @@ module RailsIds
     #
     #
     class IntegerOverflow < Sensor
-      SENSOR = 'Integer Overflow'.freeze
       TYPE = 'OVERFLOW'.freeze
 
       def self.run(_request, _params, _user, identifier)
-        event_detected(type: TYPE, weight: 'unsuspicious', sensor: SENSOR, identifier: identifier)
+        event_detected(type: TYPE, weight: 'unsuspicious', identifier: identifier)
       end
     end
   end

--- a/lib/rails_ids/sensors/login.rb
+++ b/lib/rails_ids/sensors/login.rb
@@ -8,7 +8,6 @@ module RailsIds
     # Multiple failing logins in a short time may be an brute forcing attack.
     #
     class Login < Sensor
-      SENSOR = 'Login'.freeze
       TYPE = 'LOGIN'.freeze
 
       ##
@@ -21,7 +20,7 @@ module RailsIds
       # @param identifier An identifier to recognize users without an id
       #
       def self.run(_request, _params, _user, identifier)
-        event_detected(type: TYPE, weight: 'unsuspicious', sensor: SENSOR, identifier: identifier)
+        event_detected(type: TYPE, weight: 'unsuspicious', dentifier: identifier)
       end
     end
   end

--- a/lib/rails_ids/sensors/login.rb
+++ b/lib/rails_ids/sensors/login.rb
@@ -20,7 +20,7 @@ module RailsIds
       # @param identifier An identifier to recognize users without an id
       #
       def self.run(_request, _params, _user, identifier)
-        event_detected(type: TYPE, weight: 'unsuspicious', dentifier: identifier)
+        event_detected(type: TYPE, weight: 'unsuspicious', identifier: identifier)
       end
     end
   end

--- a/lib/rails_ids/sensors/machine_learning_validation.rb
+++ b/lib/rails_ids/sensors/machine_learning_validation.rb
@@ -7,7 +7,6 @@ module RailsIds
     # Using rb-libsvm to classify the data.
     #
     class MachineLearningValidation < Sensor
-      SENSOR = 'MachineLearningValidation'.freeze
       TYPE = 'AUTOMATICALLY_RECOGNIZED'.freeze
       FILE = File.expand_path(File.join('tmp', 'rails_ids_svm'), Rails.env.test? ? '/' : Rails.root)
 
@@ -26,8 +25,7 @@ module RailsIds
 
         if suspicious
           event_detected(type: TYPE, weight: 'suspicious'.freeze,
-                         log: '',
-                         sensor: SENSOR, request: request, params: params,
+                         log: '', request: request, params: params,
                          user: user, identifier: identifier)
         end
       end

--- a/lib/rails_ids/sensors/sensor.rb
+++ b/lib/rails_ids/sensors/sensor.rb
@@ -16,7 +16,7 @@ module RailsIds
       ##
       # An event was detected and will be written into the database.
       #
-      def self.event_detected(type:, weight:, log: nil, sensor:, params: nil,
+      def self.event_detected(type:, weight:, log: nil, params: nil,
                               request: nil, user: nil, identifier: nil, match: nil)
         Event.create! event_type: type,
                       weight: weight,
@@ -27,7 +27,7 @@ module RailsIds
                       identifier: identifier,
                       controller: params.try(:[], :controller),
                       action: params.try(:[], :action),
-                      sensor: sensor,
+                      sensor: name.demodulize.freeze,
                       match: match
       end
     end

--- a/lib/rails_ids/sensors/session_ip_validation.rb
+++ b/lib/rails_ids/sensors/session_ip_validation.rb
@@ -6,7 +6,6 @@ module RailsIds
     # A implementation of an input validation sensor that blacklists some input.
     #
     class SessionIpValidation < Sensor
-      SENSOR = 'SessionIpValidation'.freeze
       TYPE = 'SESSION'.freeze
 
       def self.run(request, _params, user, identifier)
@@ -16,7 +15,7 @@ module RailsIds
         if ip != remote_ip
           event_detected(type: TYPE, weight: 'suspicious'.freeze,
                          log: "ip address changed from #{ip} #{remote_ip}",
-                         sensor: SENSOR, request: nil, params: nil,
+                         request: nil, params: nil,
                          user: user, identifier: identifier)
         end
       end


### PR DESCRIPTION
Because the `event_detected` method is implemented in `RailsIds::Sensors::Sensor`
and all sensors inherit this class, the name of the class can be found in the
method.